### PR TITLE
Offer a documentation outline based on document metadata

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: .
   specs:
-    veda (0.0.0.1)
+    veda (0.0.3.pre)
+      bundler
       coderay
       git
       hashie
@@ -42,7 +43,7 @@ GEM
       method_source (~> 0.8)
       slop (~> 3.4)
     rack (1.5.2)
-    rack-protection (1.5.0)
+    rack-protection (1.5.1)
       rack
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -55,7 +56,7 @@ GEM
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)
     simplecov-html (0.7.1)
-    sinatra (1.4.3)
+    sinatra (1.4.4)
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)

--- a/lib/veda/documentation.rb
+++ b/lib/veda/documentation.rb
@@ -34,5 +34,9 @@ module Veda
       files = Dir.glob make_path("*.md")
       files.collect { |file| fetch(File.basename(file,'.md')) }
     end
+
+    def outline
+
+    end
   end
 end

--- a/lib/veda/documentation.rb
+++ b/lib/veda/documentation.rb
@@ -12,12 +12,21 @@ module Veda
     def fetch(file)
       path = make_path("#{file}.md")
 
-      data = { title: file }
+      data = {}
       contents = File.read path
       match = contents.match /---(.*?)---(.*)/m
       if match
         data = YAML::load(match[1])
         contents = match[2]
+      end
+
+      if data['title'].nil?
+        match = contents.match /^##* ?(.+)$/
+        if match
+          data['title'] = match[1]
+        else
+          data['title'] = file
+        end
       end
 
       pages = contents.split '<!-- break -->'

--- a/lib/veda/views/index.slim
+++ b/lib/veda/views/index.slim
@@ -1,3 +1,6 @@
 - @title = 'Index'
+
+p hallo
+
 - for a in @documentation.collection
   li: a(href=url(a.id))=a.title

--- a/lib/veda/views/index.slim
+++ b/lib/veda/views/index.slim
@@ -1,6 +1,4 @@
 - @title = 'Index'
 
-p hallo
-
 - for a in @documentation.collection
   li: a(href=url(a.id))=a.title

--- a/test/documentation_test.rb
+++ b/test/documentation_test.rb
@@ -2,19 +2,23 @@ require './test/test_helper'
 
 describe "Veda::Documentation" do
   before do
-    @page = Veda::Documentation.new("./test/test-repo")
+    @documentation = Veda::Documentation.new("./test/test-repo")
   end
 
   it "should extract metadata from a single file" do
-    meta = @page.fetch "file1"
+    meta = @documentation.fetch "file1"
   end
 
   it "should not crash when no yaml" do
-    meta = @page.fetch "empty"
+    meta = @documentation.fetch "empty"
   end
 
   it "should extract metadata from a collection of files" do
-    @page.collection
+    @documentation.collection
+  end
+
+  it "should extract an outline" do
+
   end
 
   it "should use a slug as path if present"


### PR DESCRIPTION
I'd like to have an outline based on all the files in my documentation. So when I have 3 files:
- README.md
- 1-server-setup.md
- 2-deploying-an-application.md

I want to have a tree based on the metadata in those files. So this could result in a structure like:

``` ruby
['Welcome to our docs', 'How to set up your server', 'Deploying an application']
```

So we can generate a linked table of contents from it.

An addition would be that we parse markdown headings and generate something like:

``` ruby
{
  'Welcome to our docs' => 
    ['Table of contents', 'About the writers'], 
  'How to set up your server' => 
    ['Installing', 'Adding to the dashboard', ...]
}

Is this useful?
```
